### PR TITLE
Fix critical vulnerabilities in container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:20-alpine3.19
 
 RUN mkdir /sensitive_data
 COPY iac-secrets.tf /sensitive_data

--- a/app/package.json
+++ b/app/package.json
@@ -11,8 +11,8 @@
   "license": "ISC",
   "dependencies": {
     "express": "4.17.1",
-    "jest": "26.6.3",
-    "jest-junit": "13.0.0"
+    "jest": "29.7.0",
+    "jest-junit": "16.0.0",
+    "tough-cookie": "4.1.3"
   }
 }
-


### PR DESCRIPTION
## Security Fix for Critical Vulnerabilities

This PR addresses the critical security vulnerabilities identified in the `guyyakir/gh-nodejs-app:10` container image.

### Fixes:

1. **CVE-2023-26136** (CVSS Score: 9.8)
   - Updated Jest from 26.6.3 to 29.7.0
   - Explicitly added tough-cookie 4.1.3 as a dependency to ensure it's used instead of the vulnerable 4.0.0 version that was pulled in by Jest

2. **CVE-2024-5535** (CVSS Score: 9.1)
   - Updated the base Docker image from `node:16-alpine` to `node:20-alpine3.19`
   - Alpine 3.19 includes OpenSSL 3.1.6 which fixes the vulnerability in libssl3 and libcrypto3

### Additional Recommendations:

After merging this PR, please:
1. Rebuild the Docker image and tag it with a new version
2. Deploy the updated container **without** privileged permissions unless absolutely necessary
3. Follow the principle of least privilege when deploying containers

### Testing:
This change should be thoroughly tested to ensure the application continues to work as expected with the updated dependencies.

References:
- [CVE-2023-26136](https://nvd.nist.gov/vuln/detail/CVE-2023-26136)
- [CVE-2024-5535](https://nvd.nist.gov/vuln/detail/CVE-2024-5535)